### PR TITLE
refactor concerts and events

### DIFF
--- a/activities.html
+++ b/activities.html
@@ -60,7 +60,8 @@
 
   <script type="module">
     import { navBar } from './nav.js';
-    import { yearlyEvents, initGalleryComponents } from './events.js';
+    import { yearlyEvents } from './events.js';
+    import { initGalleryComponents } from './util.js';
 
     $('header.navbar').append(navBar('Activities', 0));
     initGalleryComponents();

--- a/concerts.html
+++ b/concerts.html
@@ -47,8 +47,10 @@
             <v-expansion-panel v-for="(concert,i) in concerts" :key="i">
               <v-expansion-panel-header>{{ concert.title }}</v-expansion-panel-header>
               <v-expansion-panel-content>
-                <concert-box class="center" v-bind:concert="concert">
-                  <concert-video v-if="concert.video" v-bind:url="concert.video"></concert-video>
+                <concert-box class="center" :concert="concert">
+                  <concert-video v-if="concert.video" :url="concert.video"></concert-video>
+                  <hr v-if="concert.pics" />
+                  <gallery v-if="concert.pics" v-bind:event="concert" :showTitle="false" class="my-5"></gallery>
                 </concert-box>
               </v-expansion-panel-content>
             </v-expansion-panel>
@@ -60,12 +62,12 @@
 
   <script type="module">
     import { navBar } from './nav.js';
-    import { dawn, echo } from './concerts.js';
-    import { initVue } from './util.js';
+    import { dawn, echo, initConcertComponents } from './concerts.js';
+    import { initGalleryComponents } from './util.js';
 
     $('header.navbar').append(navBar('Concerts', 0));
-
-    initVue();
+    initConcertComponents();
+    initGalleryComponents();
 
     new Vue({
       el: '#concerts',

--- a/concerts.js
+++ b/concerts.js
@@ -12,8 +12,24 @@ const echo = {
   datetime: 'Sunday, Dec 5, 2021 6:30 pm',
   venue: [ 'Forum Theatre, Yorba Linda High School',
            '4175 Fairmont Blvd, Yorba Linda, CA 92886' ],
-  poster: 'img/echo.jpg',
   beneficiary: ['Malala Foundation', 'https://malala.org'],
+  poster: 'img/echo.jpg',
+  pics: [
+    './img/pc055426.jpg',
+    './img/pc055453.jpg',
+    './img/pc055504.jpg',
+    './img/pc055574.jpg',
+    './img/pc055649.jpg',
+    './img/pc055842.jpg',
+    './img/pc055908.jpg',
+    './img/pc056011.jpg',
+    './img/pc056165.jpg',
+    './img/pc056267.jpg',
+    './img/pc056359.jpg',
+    './img/pc056443.jpg',
+    './img/pc056556.jpg',
+    './img/pc056617.jpg',
+  ],
   video: 'https://www.youtube.com/embed/98-eAkatJSY',
   program: [
     [ 'River Flows in You', 'Yiruma', 'Tina Hou, piano' ],
@@ -34,4 +50,45 @@ const echo = {
   ]
 };
 
-export { dawn, echo };
+function initConcertComponents() {
+  Vue.component('concert-box', {
+    props: ['concert'],
+    template: '<div class="concert-box">' +
+                '<table class="concert-table">' +
+                '<tr>' + 
+                '  <th>Date and Time</th>' +
+                '  <td>{{ concert.datetime }}</td>' +
+                '</tr><tr>' +
+                '  <th>Venue</th>' +
+                '  <td>{{ concert.venue[0] }}<br>{{ concert.venue[1] }}</td>' +
+                '</tr><tr>' +
+                '  <th>Beneficiary</th>' +
+                '  <td><a :href=concert.beneficiary[1] target="_blank">{{ concert.beneficiary[0] }}</a></td>' +
+                '</tr>' +
+                '</table>' +
+                '<img class="concert-poster figure-img img-fluid rounded" :src="concert.poster">' +
+                '<slot></slot>' +
+              '</div>'
+  });
+
+  Vue.component('concert-video', {
+    props: ['url'],
+    template: '<div class="video-wrap mb-5"><div class="video-container">' +
+                '<iframe :src="url" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>' +
+              '</div></div>'
+  });
+
+  Vue.component('concert-program', {
+    props: ['program'],
+    template: '<div class="concert-program">' +
+                '<h3>Concert Program</h3>' +
+                '<v-card v-for="(item,i) in program" :key="i" class="mx-auto my-3">' +
+                  '<v-card-title>{{item[0]}}</v-card-title>' +
+                  '<v-card-subtitle>composer(s): {{item[1]}}</v-card-subtitle>' +
+                  '<v-card-text>performer(s): {{item[2]}}</v-card-text>' +
+                '</v-card>' +
+              '</div>'
+  });
+}
+
+export { dawn, echo, initConcertComponents };

--- a/events.js
+++ b/events.js
@@ -1,25 +1,18 @@
-const events2021 = [
+const events2022 = [
   {
-    name: 'The Echo',
-    date: 'December 5th',
+    name: 'College Admission Sharing',
+    date: 'May 13th',
     desc: '',
     pics: [
-      './img/pc055426.jpg',
-      './img/pc055453.jpg',
-      './img/pc055504.jpg',
-      './img/pc055574.jpg',
-      './img/pc055649.jpg',
-      './img/pc055842.jpg',
-      './img/pc055908.jpg',
-      './img/pc056011.jpg',
-      './img/pc056165.jpg',
-      './img/pc056267.jpg',
-      './img/pc056359.jpg',
-      './img/pc056443.jpg',
-      './img/pc056556.jpg',
-      './img/pc056617.jpg',
+      './img/college_sharing_2201.jpg',
+      './img/college_sharing_2202.jpg',
+      './img/college_sharing_2203.jpg',
+      './img/college_sharing_2204.jpg',
     ]
-  },
+  }
+];
+
+const events2021 = [
   {
     name: 'Summer Gathering',
     date: 'August',
@@ -67,7 +60,10 @@ const events2019 = [
 ];
 
 const yearlyEvents = [
-  {
+  { 
+    year: 2022,
+    events: events2022
+  }, {
     year: 2021,
     events: events2021 
   }, {
@@ -76,24 +72,4 @@ const yearlyEvents = [
   }
 ];
 
-function initGalleryComponents() {
-  Vue.component('gallery', {
-    props: ['event', 'showTitle'],
-    template: '<div class="imageitem">' +
-              '  <v-card elevation="2" class="gallery">' +
-              '    <v-card-title v-if=showTitle>{{ `${event.name}, ${event.date}` }}</v-card-title>' +
-              '    <v-carousel eager>' +
-              '      <v-carousel-item' +
-              '        v-for="item in event.pics"' +
-              '        :src=item' +
-              '        reverse-transition="fade-transition"' +
-              '        transition="fade-transition"' +
-              '        ripple="true"' +
-              '      ></v-carousel-item>' +
-              '    </v-carousel>' +
-              '  </v-card>' +
-              '</div>'
-  });
-};
-
-export { yearlyEvents, initGalleryComponents };
+export { yearlyEvents };

--- a/util.js
+++ b/util.js
@@ -1,42 +1,21 @@
-function initVue() {
-  Vue.component('concert-box', {
-    props: ['concert'],
-    template: '<div class="concert-box">' +
-                '<table class="concert-table">' +
-                '<tr>' + 
-                '  <th>Date and Time</th>' +
-                '  <td>{{ concert.datetime }}</td>' +
-                '</tr><tr>' +
-                '  <th>Venue</th>' +
-                '  <td>{{ concert.venue[0] }}<br>{{ concert.venue[1] }}</td>' +
-                '</tr><tr>' +
-                '  <th>Beneficiary</th>' +
-                '  <td><a :href=concert.beneficiary[1] target="_blank">{{ concert.beneficiary[0] }}</a></td>' +
-                '</tr>' +
-                '</table>' +
-                '<img class="concert-poster figure-img img-fluid rounded mb-5" :src="concert.poster">' +
-                '<slot></slot>' +
+function initGalleryComponents() {
+  Vue.component('gallery', {
+    props: ['event', 'showTitle'],
+    template: '<div class="imageitem">' +
+              '  <v-card elevation="2" class="gallery">' +
+              '    <v-card-title v-if=showTitle>{{ `${event.name}, ${event.date}` }}</v-card-title>' +
+              '    <v-carousel eager>' +
+              '      <v-carousel-item' +
+              '        v-for="item in event.pics"' +
+              '        :src=item' +
+              '        reverse-transition="fade-transition"' +
+              '        transition="fade-transition"' +
+              '        ripple="true"' +
+              '      ></v-carousel-item>' +
+              '    </v-carousel>' +
+              '  </v-card>' +
               '</div>'
   });
+};
 
-  Vue.component('concert-video', {
-    props: ['url'],
-    template: '<div class="video-wrap mb-5"><div class="video-container">' +
-                '<iframe :src="url" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>' +
-              '</div></div>'
-  });
-
-  Vue.component('concert-program', {
-    props: ['program'],
-    template: '<div class="concert-program">' +
-                '<h3>Concert Program</h3>' +
-                '<v-card v-for="(item,i) in program" :key="i" class="mx-auto my-3">' +
-                  '<v-card-title>{{item[0]}}</v-card-title>' +
-                  '<v-card-subtitle>composer(s): {{item[1]}}</v-card-subtitle>' +
-                  '<v-card-text>performer(s): {{item[2]}}</v-card-text>' +
-                '</v-card>' +
-              '</div>'
-  });
-}
-
-export { initVue };
+export { initGalleryComponents };


### PR DESCRIPTION
Changes in this PR,

1. Move gallery component from events.js to util.js, since it's shared by concerts and events.
2. Move concerts components from util.js to concert.js, since it's only used by concerts.
3. Add a gallery in concert-box. There was a decision in the meeting on 8/13, separate concerts and other activities/events. A concert has its own gallery on Concerts page, and a non-concert event displays on Activities page.